### PR TITLE
Joe monday helly testing

### DIFF
--- a/app/controllers/addCustPaymentOptC.js
+++ b/app/controllers/addCustPaymentOptC.js
@@ -10,7 +10,7 @@ module.exports.newPaymentOption = (activeCustomerId) => {
       allPaymentTypes.forEach(pt=>{
         console.log(pt.payment_type_id, pt.name);
       });
-      prompt.get(paymentOptionPrompts,
+      prompt.get(paymentOptionPrompts(allPaymentTypes),
         (err, result) => {
           if(+result.paymentType>= allPaymentTypes.length || +result.paymentType < 0){
             reject("That is not a valid payment type, ya jabroni!")

--- a/app/controllers/addCustPaymentOptC.js
+++ b/app/controllers/addCustPaymentOptC.js
@@ -12,7 +12,7 @@ module.exports.newPaymentOption = (activeCustomerId) => {
       });
       prompt.get(paymentOptionPrompts,
         (err, result) => {
-          if(+result.paymentType> allPaymentTypes.length || +result.paymentType < 0){
+          if(+result.paymentType>= allPaymentTypes.length || +result.paymentType < 0){
             reject(console.log("That is not a valid payment type, ya jabroni!"))
           }
           // build an object of payment type and account #

--- a/app/controllers/addCustPaymentOptC.js
+++ b/app/controllers/addCustPaymentOptC.js
@@ -6,12 +6,15 @@ const { getAllPaymentTypes } = require('../models/PaymentTypesM');
 module.exports.newPaymentOption = (activeCustomerId) => {
   return new Promise((resolve, reject) => {
     getAllPaymentTypes()
-    .then(paymentTypes=>{
-      paymentTypes.forEach(pt=>{
+    .then(allPaymentTypes=>{
+      allPaymentTypes.forEach(pt=>{
         console.log(pt.payment_type_id, pt.name);
       });
       prompt.get(paymentOptionPrompts,
         (err, result) => {
+          if(+result.paymentType> allPaymentTypes.length || +result.paymentType < 0){
+            reject(console.log("That is not a valid payment type, ya jabroni!"))
+          }
           // build an object of payment type and account #
           let paymentOption = {
             payment_type: result.paymentType,

--- a/app/controllers/addCustPaymentOptC.js
+++ b/app/controllers/addCustPaymentOptC.js
@@ -13,7 +13,7 @@ module.exports.newPaymentOption = (activeCustomerId) => {
       prompt.get(paymentOptionPrompts,
         (err, result) => {
           if(+result.paymentType>= allPaymentTypes.length || +result.paymentType < 0){
-            reject(console.log("That is not a valid payment type, ya jabroni!"))
+            reject("That is not a valid payment type, ya jabroni!")
           }
           // build an object of payment type and account #
           let paymentOption = {

--- a/app/controllers/addCustPaymentOptC.js
+++ b/app/controllers/addCustPaymentOptC.js
@@ -35,10 +35,4 @@ module.exports.saveNewPaymentOption = (paymentOptionObject)=>{
     });
   });
 };
-// FOR REFERENCE: this is what the payment option object will look like when it eventually gets sent to the DB
-// {
-//   "payment_option_id": 0,
-//   "type": 5,
-//   "account_number": "12556622",
-//   "customer_id": 1
-// }
+

--- a/app/views/addCustPaymentOptV.js
+++ b/app/views/addCustPaymentOptV.js
@@ -1,14 +1,21 @@
-module.exports.paymentOptionPrompts = [
-  {
-    name: 'paymentType',
-    description: 'Please enter a payment option',
-    required: true,
-    pattern: '^[0-9 ]*$'
-  },
-  {
-    name: 'accountNumber',
-    description: 'Please enter your account number',
-    required: true,
-    pattern: '^[0-9 ]*$'
-  }
-]
+module.exports.paymentOptionPrompts = (paymentTypesArray)=>{
+  const typesRegEx = new RegExp(`^[0-${paymentTypesArray.length}]$`);
+  
+  const newPaymentOption =  [
+    {
+      name: 'paymentType',
+      description: 'Please enter a payment option',
+      required: true,
+      conform: (userInput)=>{
+        return (userInput < paymentTypesArray.length) && (userInput >= 0) ? true : false;
+      }
+    },
+    {
+      name: 'accountNumber',
+      description: 'Please enter your account number',
+      required: true,
+      pattern: '^[0-9 ]*$'
+    }
+  ];
+  return newPaymentOption;
+}

--- a/app/views/addCustPaymentOptV.js
+++ b/app/views/addCustPaymentOptV.js
@@ -3,7 +3,7 @@ module.exports.paymentOptionPrompts = [
     name: 'paymentType',
     description: 'Please enter a payment option',
     required: true,
-    type: 'string'
+    pattern: '^[0-9 ]*$'
   },
   {
     name: 'accountNumber',


### PR DESCRIPTION
# Description
This fixes that users could select a payment type that was no available.

## Related Ticket(s)
Fixes #55 
## Problem to Solve
Invalid payment types were in the payment options

## Proposed Changes
Describe the proposed changes.

## Expected Behavior
Should send back an error whether you type in a negative number (will immedaitely throw an error bc characters besides numers are not allowed in the prompt. OR if you type in a number thats higher than the length of our payment types list then it will console log an error after you try to submit an account number.

## Steps to Test Solution

1. run `npm start`
2. select `2` and enter a valid customer id
3. select `3` and try to type in `-1` (or any negative number). this will throw an error immediately bc the `-` character is not allowed in that prompt. 
4. select `3` from the MAIN MENU again and type in a number greater than 18. The error is not thrown immediately bc the prompt has not finished yet, so the invalid number has not been assessed/submitted yet. You must type in an account number and THEN it will throw console log error and reject that new payment option

## Testing

- [ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [ ] I certify that all existing tests pass

## Documentation
- [ ] There is new documentation in this pull request that must be reviewed..
- [ ] I added documentation for any new classes/methods

