### PR TITLE
Fixes #57: This mfing regex is dope and I hate prompt

### DIFF
--- a/app/views/addCustProdV.js
+++ b/app/views/addCustProdV.js
@@ -3,16 +3,16 @@ const colors = require('colors/safe');
 
 module.exports.addCustProdV = [{
   name: 'productType',
-  description: 'Enter Product Category by number',
+  description: 'Enter product category by number',
   pattern: /^[0-9 ]*$/,
   message: colors.red("Selection invalid: product type does not exist, please select a numerical value from the list above"),
   required: true
 }, {
   name: 'productName',
-  description: 'Enter Product name',
+  description: 'Enter product name',
   type: 'string',
   required: true
-},{
+}, {
   name: 'productPrice',
   description: 'Enter product price',
   pattern: /^\d+\.\d{2}$/,
@@ -23,10 +23,10 @@ module.exports.addCustProdV = [{
   description: 'Enter product description',
   type: 'string',
   required: true
-},
-{
+}, {
   name: 'productQuantity',
-  description: 'Enter Product Quantity',
-  type: 'integer',
+  description: 'Enter product quantity',
+  pattern: /^\d+$/,
+  message: colors.red("Please enter a whole, positive integer"),
   required: true
-}]
+}];


### PR DESCRIPTION
# Description
Users were able to input negative integers into the product quantity for a new product. That is not a great idea.
Also, fixes up the formatting for the questions a bit

## Related Ticket(s)
Fixes #57

## Problem to Solve
This creates the proper regex to fix users being able to input only positive integers

## Expected Behavior
User should only be able to input positive integers for product quantity

## Steps to Test Solution

1. `npm test`
1. `npm start`
1. Select `2` and any customer
1. Select `4` and start going through the prompts
1. When you get to `product quantity`, input a floating point, input random letters & symbols, input a negative whole number. The prompt should reject all of these.
1. Input a whole, positive number and the prompt should accept it!

## Testing

- [x] I certify that all existing tests pass