### PR TITLE
fixed the decimal thing for adding a payment type

### DIFF
--- a/app/controllers/addCustPaymentOptC.js
+++ b/app/controllers/addCustPaymentOptC.js
@@ -10,7 +10,7 @@ module.exports.newPaymentOption = (activeCustomerId) => {
       paymentTypes.forEach(pt=>{
         console.log(pt.payment_type_id, pt.name);
       });
-      prompt.get(paymentOptionPrompts(allPaymentTypes),
+      prompt.get(paymentOptionPrompts(paymentTypes),
         (err, result) => {
           // build an object of payment type and account #
           let paymentOption = {

--- a/app/views/addCustPaymentOptV.js
+++ b/app/views/addCustPaymentOptV.js
@@ -7,7 +7,7 @@ module.exports.paymentOptionPrompts = (paymentTypesArray)=>{
       description: 'Please enter a payment option',
       required: true,
       conform: (userInput)=>{
-        return (userInput < paymentTypesArray.length) && (userInput >= 0) ? true : false;
+        return (userInput < paymentTypesArray.length) && (userInput >= 0) && Number.isInteger(+userInput) ? true : false;
       }
     },
     {


### PR DESCRIPTION
# LOOK AT MY CHANGED FILES. THAT ONE VARIABLE NAME I CHANGED NEEDS TO BE WHAT MINE SAYS NOT WHAT MASTER SAYS

# Description
Fixed the bug where you could type in decimals as a payment type when creating a new payment option

## Related Ticket(s)


## Problem to Solve
Just adds a little more strictness to our input

## Proposed Changes


## Expected Behavior
should throw error when you try to type in a decimal place as a payment type when creating new payment option

## Steps to Test Solution

1. run `npm start`
2. select an active user
3. select `3` and try to add a payment option that has a payment type of a decimal number

## Testing

- [ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [ ] I certify that all existing tests pass





## Documentation
- [ ] There is new documentation in this pull request that must be reviewed..
- [ ] I added documentation for any new classes/methods

